### PR TITLE
fix(Line & Area): update scale config in line storybook

### DIFF
--- a/src/line/demos/Line.stories.tsx
+++ b/src/line/demos/Line.stories.tsx
@@ -159,11 +159,11 @@ const LineWithOneLineDateConfig = {
       range: [0, 1],
     },
     value: {
-      min: 0,
+      // min: 0,
       // type: 'quantize',
       // type: 'quantile',
       // ticks: [0, 2000, 4000, 8000, 10000],
-      tickCount: 5,
+      // tickCount: 5,
       nice: true,
       formatter: (x: string) => String(x).replace(/\B(?=(\d{3})+(?!\d))/g, ','),
     },

--- a/src/line/demos/Line.stories.tsx
+++ b/src/line/demos/Line.stories.tsx
@@ -29,8 +29,7 @@ const Template: ComponentStory<typeof Line> = (args) => (
 const scalaAxisConfig = {
   scale: {
     value: {
-      tickCount: 10,
-      min: 0,
+      nice: true,
     },
     tm: { range: [0, 1] },
   },


### PR DESCRIPTION
* Line Chart
before fixes:
![image](https://user-images.githubusercontent.com/7121951/136492102-99d02fe0-d7a6-45b7-be89-b3d16666fd7f.png)

after fixes:
![image](https://user-images.githubusercontent.com/7121951/136492066-37720c8c-c5fc-4aba-aab8-eef6847a0d43.png)

* Area Chart
before fixes:
![image](https://user-images.githubusercontent.com/7121951/136492250-8689670e-f52e-4016-82dc-ec2415a423e2.png)

after fixes:
![image](https://user-images.githubusercontent.com/7121951/136492228-c03700f7-9c03-4016-955c-bbbd1bdd6cc2.png)
