### PR TITLE
fix(react): move react repos to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,8 +119,8 @@
     "webpack": "4.44.2"
   },
   "peerDependencies": {
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "react": ">=16.13.0",
+    "react-dom": ">=16.13.0"
   },
   "resolutions": {
     "babel-loader": "8.1.0"

--- a/package.json
+++ b/package.json
@@ -103,8 +103,6 @@
     "less": "3.13.1",
     "less-loader": "6.0.0",
     "prettier": "^2.3.2",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
     "react-docgen-typescript-plugin": "^1.0.0",
     "react-scripts": "4.0.3",
     "style-loader": "1.3.0",
@@ -119,6 +117,10 @@
     "typescript": "^4.1.2",
     "typings-for-css-modules-loader": "^1.7.0",
     "webpack": "4.44.2"
+  },
+  "peerDependencies": {
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
   },
   "resolutions": {
     "babel-loader": "8.1.0"

--- a/package.json
+++ b/package.json
@@ -66,9 +66,7 @@
     "@antv/util": "^2.0.17",
     "@babel/runtime": "^7.15.4",
     "date-fns": "^2.23.0",
-    "lodash": "^4.17.21",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",
@@ -105,6 +103,8 @@
     "less": "3.13.1",
     "less-loader": "6.0.0",
     "prettier": "^2.3.2",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
     "react-docgen-typescript-plugin": "^1.0.0",
     "react-scripts": "4.0.3",
     "style-loader": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "less": "3.13.1",
     "less-loader": "6.0.0",
     "prettier": "^2.3.2",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
     "react-docgen-typescript-plugin": "^1.0.0",
     "react-scripts": "4.0.3",
     "style-loader": "1.3.0",

--- a/src/info-card/InfoCardBox.tsx
+++ b/src/info-card/InfoCardBox.tsx
@@ -65,7 +65,7 @@ const InfoCardBox = (props: InfoCardProps) => {
           }
           return { ...legend, data: { ...itemData }, type: chartType, styles: legendStyles };
         }) || [];
-      const showTitle = (items[0] as LooseObject)?.data?.[nameKey] || triggerItems?.[0]?.name || '';
+      const showTitle = (triggerItems?.[0] as LooseObject)?.data?.[nameKey] || triggerItems?.[0]?.name || '';
       setTitle(showTitle);
       setItems(covertItems);
     });

--- a/src/info-card/Item.tsx
+++ b/src/info-card/Item.tsx
@@ -12,7 +12,7 @@ export interface ItemProps {
 const Item = (props: ItemProps) => {
   const { data, forwardKey, valueKey = '', formatter } = props;
   const item = data?.data;
-  const value = item?.[valueKey] || item?.value;
+  const value = item?.[valueKey] || item?.value || 0;
   const defaultConvertValue = isNaN(Number(value)) ? value : formatNumber(Number(value));
   const formatedValue = formatter ? formatter(value) : defaultConvertValue;
   return (

--- a/src/utils/analysis/analysisSourceData.ts
+++ b/src/utils/analysis/analysisSourceData.ts
@@ -1,8 +1,7 @@
 import { LooseObject } from '@antv/component';
 
-const analysisRow = (chartType: string, data: LooseObject, column: LooseObject) => {
-  return chartType === 'column' && column.id === 'tm' ? String(data) : data;
-};
+const analysisRow = (chartType: string, data: LooseObject, column: LooseObject) =>
+  chartType === 'column' && column.id === 'tm' ? String(data) : data;
 
 export interface AnalysisOptions {
   // chart的类型

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -33,7 +33,7 @@ export const getInfoCardStyles = (
     color = color || item.color;
   } else {
     // if color isn't equal with first position, it's ok to use color in legend
-    color = color || legend.color;
+    color = color || legend.color || item.color;
   }
   return [legend, color];
 };


### PR DESCRIPTION
Reference https://reactjs.org/warnings/invalid-hook-call-warning.html

We move react repos to peerDependencies to resolve `more than one copy react` issue.

@gio-design/charts uses react which be provided by main project. 