### PR TITLE
fix(padding): add default padding to resolve the label of chart is out the canvas issue

### DIFF
--- a/src/core/framework.ts
+++ b/src/core/framework.ts
@@ -25,6 +25,8 @@ export const generateChart = (options: ChartOptions, config: ChartConfig) => {
     container: id as HTMLElement,
     autoFit: basicConfig.autoFit === undefined ? DEFAULT_AUTO_FIT : basicConfig.autoFit,
     height: basicConfig.height || DEFAULT_HEIGHT,
+    padding: 'auto',
+    appendPadding: 8,
     theme: merge(cloneDeep(gioTheme), cloneDeep(theme), customTheme),
   });
   if (basicConfig.closeAnimate) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7121951/140246402-f9f5d4bd-d5cf-4ebd-89de-84ef43e69d7c.png)

After:
![image](https://user-images.githubusercontent.com/7121951/140246421-46517894-7d0a-4c67-a59b-1179da8d0081.png)
