### PR TITLE
docs(release): release version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [1.1.0](https://github.com/growingio/gio-design-charts/compare/v1.0.0-beta.11...v1.1.0) (2021-11-15)
+
+
+### Bug Fixes
+
+* **Gauge:** support update function ([#132](https://github.com/growingio/gio-design-charts/issues/132)) ([fd95ecf](https://github.com/growingio/gio-design-charts/commit/fd95ecfdbe7a6abd95a7763c60605b2d0bcf6f4e))
+* **resize:** chart should re-render when resize ([#137](https://github.com/growingio/gio-design-charts/issues/137)) ([c1807c4](https://github.com/growingio/gio-design-charts/commit/c1807c4cea92ead19a2144484140d013c31b61b3))
+* **sonar:** resolve sonar issues. ([#140](https://github.com/growingio/gio-design-charts/issues/140)) ([2bd756e](https://github.com/growingio/gio-design-charts/commit/2bd756e6e414743e0ee8cd86c212c089f19fca2d))
+
+
+### Features
+
+* **Donut:** donut chart improve ([#134](https://github.com/growingio/gio-design-charts/issues/134)) ([1bde1ab](https://github.com/growingio/gio-design-charts/commit/1bde1abc1d6a39c1c65670852cbac79a3ac964da))
+* **Gauge:** add Gauge chart ([#131](https://github.com/growingio/gio-design-charts/issues/131)) ([0d3fce2](https://github.com/growingio/gio-design-charts/commit/0d3fce2a733bbd3e967abbfd59da200d699374b6))
+* **TimeIntervalBar:** Add TimeIntervalBar ([#136](https://github.com/growingio/gio-design-charts/issues/136)) ([28e0feb](https://github.com/growingio/gio-design-charts/commit/28e0feb1775c1ff5cf62a1abd21aa4cc05bff827))
+
+
+
 # [1.0.0-beta.13](https://github.com/growingio/gio-design-charts/compare/v1.0.0-beta.11...v1.0.0-beta.13) (2021-11-12)
 
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,15 +1,18 @@
-# [1.0.0-beta.13](https://github.com/growingio/gio-design-charts/compare/v1.0.0-beta.11...v1.0.0-beta.13) (2021-11-12)
+# [1.1.0](https://github.com/growingio/gio-design-charts/compare/v1.0.0-beta.11...v1.1.0) (2021-11-15)
 
 
 ### Bug Fixes
 
 * **Gauge:** support update function ([#132](https://github.com/growingio/gio-design-charts/issues/132)) ([fd95ecf](https://github.com/growingio/gio-design-charts/commit/fd95ecfdbe7a6abd95a7763c60605b2d0bcf6f4e))
+* **resize:** chart should re-render when resize ([#137](https://github.com/growingio/gio-design-charts/issues/137)) ([c1807c4](https://github.com/growingio/gio-design-charts/commit/c1807c4cea92ead19a2144484140d013c31b61b3))
+* **sonar:** resolve sonar issues. ([#140](https://github.com/growingio/gio-design-charts/issues/140)) ([2bd756e](https://github.com/growingio/gio-design-charts/commit/2bd756e6e414743e0ee8cd86c212c089f19fca2d))
 
 
 ### Features
 
 * **Donut:** donut chart improve ([#134](https://github.com/growingio/gio-design-charts/issues/134)) ([1bde1ab](https://github.com/growingio/gio-design-charts/commit/1bde1abc1d6a39c1c65670852cbac79a3ac964da))
 * **Gauge:** add Gauge chart ([#131](https://github.com/growingio/gio-design-charts/issues/131)) ([0d3fce2](https://github.com/growingio/gio-design-charts/commit/0d3fce2a733bbd3e967abbfd59da200d699374b6))
+* **TimeIntervalBar:** Add TimeIntervalBar ([#136](https://github.com/growingio/gio-design-charts/issues/136)) ([28e0feb](https://github.com/growingio/gio-design-charts/commit/28e0feb1775c1ff5cf62a1abd21aa4cc05bff827))
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gio-design/charts",
-  "version": "1.0.0-beta.13",
+  "version": "1.1.0",
   "main": "lib/index.js",
   "module": "es/index.js",
   "unpkg": "dist/charts.umd.min.js",


### PR DESCRIPTION
Features:

- 支持间隔分析图TimeIntervalBar；
- 仪表图Gauge支持“暂无数据”显示；
- 柱状图柱宽和间距按照1:1显示，默认最小40px，最大100px；

Fixes:

- 在div或者浏览器size变化的时候，重新调用chart.render(true);