### PR TITLE
fix: split-line样式，cursor和tooltip的新支持

### DIFF
--- a/src/core/framework.ts
+++ b/src/core/framework.ts
@@ -1,5 +1,6 @@
-import { Chart, registerInteraction, View } from '@antv/g2';
+import { Chart, registerAction, registerInteraction, View } from '@antv/g2';
 import { AxisOption, Datum, ScaleOption } from '@antv/g2/lib/interface';
+import CursorAction from '@antv/g2/lib/interaction/action/cursor';
 import { isEmpty } from 'lodash';
 import { Actions, ChartConfig, ChartOptions, Legends } from '../interfaces';
 import { DEFAULT_APPEND_PADDING, DEFAULT_AUTO_FIT, DEFAULT_TINY_APPEND_PADDING } from '../theme';
@@ -12,6 +13,8 @@ registerInteraction('element-highlight-by-color', {
   start: [{ trigger: 'element:mouseenter', action: 'element-highlight-by-color:highlight' }],
   end: [{ trigger: 'element:mouseleave', action: 'element-highlight-by-color:reset' }],
 });
+
+registerAction('cursor', CursorAction);
 
 export const generateChart = (options: ChartOptions, config: ChartConfig) => {
   const { id, theme } = options;
@@ -95,8 +98,10 @@ export const fetchConfig = (chart: Chart | View, options: ChartOptions, config: 
 
   // We don't use default legend
   chart.legend(false);
-  chart.interaction('element-active');
-
+  chart.interaction('element-active', {
+    start: [{ trigger: 'element:mouseenter', action: 'cursor:pointer' }],
+    end: [{ trigger: 'element:mouseleave', action: 'cursor:pointer' }],
+  });
   return chart;
 };
 

--- a/src/funnel/demos/Funnel.stories.tsx
+++ b/src/funnel/demos/Funnel.stories.tsx
@@ -98,6 +98,7 @@ const FunnelWith3ColumnsArgs = {
       // shared: true,
       showMarkers: false,
       clickOffset: 62,
+      // clickFixedOffset: 100,
       render: (options: any) => {
         return <DrillDownCard options={options} />;
       },

--- a/src/funnel/demos/Funnel.stories.tsx
+++ b/src/funnel/demos/Funnel.stories.tsx
@@ -95,10 +95,12 @@ const FunnelWith3ColumnsArgs = {
     tooltip: {
       enterable: true,
       showContent: true,
-      // shared: true,
       showMarkers: false,
-      clickOffset: 62,
-      // clickFixedOffset: 100,
+      clickOptions: {
+        visible: true,
+        offsetY: 62,
+        fixedOffsetY: 100,
+      },
       render: (options: any) => {
         return <DrillDownCard options={options} />;
       },

--- a/src/funnel/framework.ts
+++ b/src/funnel/framework.ts
@@ -134,7 +134,11 @@ export class Funnel extends BaseChart {
       fetchTooltip(this.instance, config);
       this.instance.legend(false);
       this.instance.render();
-      interceptors?.bindElementEvents(this.instance, { more: true, offset: get(config, 'tooltip.clickOffset') });
+      interceptors?.bindElementEvents(this.instance, {
+        more: true,
+        offset: get(config, 'tooltip.clickOffset'),
+        fixedOffset: get(config, 'tooltip.clickFixedOffset'),
+      });
     } catch (err) {
       /* istanbul ignore next */
       console.log(err);

--- a/src/funnel/framework.ts
+++ b/src/funnel/framework.ts
@@ -7,6 +7,7 @@ import { BaseChart, fetchTooltip, fetchViewConfig, generateChart } from '../core
 import { addLinkByElementHigh } from '../utils/tools/elementLink';
 import gioTheme, { viewTheme } from '../theme/chart';
 import { LooseObject } from '@antv/g-base';
+import { InterceptorOptions } from '../hooks/useInterceptors';
 
 export class Funnel extends BaseChart {
   fetchInterval = (chart: Chart | View, options: ChartOptions, config: ChartConfig) => {
@@ -134,11 +135,12 @@ export class Funnel extends BaseChart {
       fetchTooltip(this.instance, config);
       this.instance.legend(false);
       this.instance.render();
-      interceptors?.bindElementEvents(this.instance, {
-        more: true,
-        offset: get(config, 'tooltip.clickOffset'),
-        fixedOffset: get(config, 'tooltip.clickFixedOffset'),
-      });
+
+      const clickVisible = get(config, 'tooltip.clickOptions.visible');
+      interceptors?.bindElementEvents?.(this.instance, {
+        ...get(config, 'tooltip.clickOptions'),
+        visible: clickVisible === undefined ? true : clickVisible,
+      } as InterceptorOptions);
     } catch (err) {
       /* istanbul ignore next */
       console.log(err);

--- a/src/hooks/__test__/useInterceptors.test.tsx
+++ b/src/hooks/__test__/useInterceptors.test.tsx
@@ -10,7 +10,7 @@ describe('test useInterceptors', () => {
     (chartObj as any).lockTooltip = jest.fn;
     (chartObj as any).unlockTooltip = jest.fn;
     act(() => {
-      result.current.interceptors.bindElementEvents(chartObj as any);
+      result.current.interceptors?.bindElementEvents(chartObj as any);
     });
 
     act(() => {

--- a/src/hooks/useChart.ts
+++ b/src/hooks/useChart.ts
@@ -6,7 +6,7 @@ import { isEqual } from '@antv/util';
 import { Actions, ChartConfig } from '../interfaces';
 import { LegendObject } from '../legends/useLegends';
 import { getTheme, inValidConfig } from '../utils/chart';
-import { cloneDeep, isObject } from 'lodash';
+import { cloneDeep, get, isObject } from 'lodash';
 import { DesignContext } from '@gio-design/utils';
 import { useIntlDict } from './useIntlDict';
 
@@ -114,7 +114,11 @@ const useChart = (options: UseChartProps) => {
       configRef.current = cloneDeep(config);
       dataRef.current = cloneDeep(data);
       // setLegends(genLegends, queue, hasDashedLegend);
-      interceptors?.bindElementEvents(chart.instance);
+      interceptors?.bindElementEvents(chart.instance, {
+        more: get(config, 'tooltip.clickOffset'),
+        offset: get(config, 'tooltip.clickOffset'),
+        fixedOffset: get(config, 'tooltip.clickFixedOffset'),
+      });
     }
   }, [
     rootRef,

--- a/src/hooks/useChart.ts
+++ b/src/hooks/useChart.ts
@@ -114,11 +114,7 @@ const useChart = (options: UseChartProps) => {
       configRef.current = cloneDeep(config);
       dataRef.current = cloneDeep(data);
       // setLegends(genLegends, queue, hasDashedLegend);
-      interceptors?.bindElementEvents(chart.instance, {
-        more: get(config, 'tooltip.clickOffset'),
-        offset: get(config, 'tooltip.clickOffset'),
-        fixedOffset: get(config, 'tooltip.clickFixedOffset'),
-      });
+      interceptors?.bindElementEvents?.(chart.instance, get(config, 'tooltip.clickOptions'));
     }
   }, [
     rootRef,

--- a/src/hooks/useInterceptors.ts
+++ b/src/hooks/useInterceptors.ts
@@ -5,9 +5,10 @@ export interface InterceptorOptions {
   visible?: boolean;
   offsetY?: number;
   fixedOffsetY?: number;
-  more?: boolean;
-  offset?: number;
-  fixedOffset?: number;
+}
+export interface Interceptor {
+  bindTooltip: (ref: any) => void;
+  bindElementEvents: (chart: Chart, options?: InterceptorOptions) => void;
 }
 
 const useInterceptors = () => {
@@ -28,26 +29,23 @@ const useInterceptors = () => {
 
   const [, updated] = useState(0);
 
-  const interceptors = useMemo(() => {
+  const interceptors: Interceptor = useMemo(() => {
     return {
       bindTooltip(r: any) {
         tooltipRef.current = r?.current;
       },
-      bindElementEvents(chart: Chart, options: InterceptorOptions = {}) {
+      bindElementEvents(chart: Chart, options?: InterceptorOptions) {
         chartRef.current = chart;
         chart.on('element:click', () => {
           /* istanbul ignore next */
-          if (triggerActionRef.current !== 'click' && tooltipRef.current && options.more) {
+          if (triggerActionRef.current !== 'click' && tooltipRef.current && options?.visible) {
             const tipStyles = window.getComputedStyle(tooltipRef?.current);
             const top = parseInt(tipStyles.top);
             const height = parseInt(tipStyles.height);
 
-            const { offset = 70, fixedOffset } = options;
-            if (fixedOffset) {
-              tooltipRef.current.style.top = `${top + height - fixedOffset}px`;
-            } else if (top && top > offset) {
-              tooltipRef.current.style.top = `${top - offset}px`;
-            }
+            const { offsetY = 70, fixedOffsetY } = options;
+            const revisedOffsetY = fixedOffsetY ? top + height - fixedOffsetY : top - offsetY;
+            tooltipRef.current.style.top = `${revisedOffsetY}px`;
           }
           triggerActionRef.current = 'click';
           chart.lockTooltip();

--- a/src/hooks/useInterceptors.ts
+++ b/src/hooks/useInterceptors.ts
@@ -1,6 +1,15 @@
 import { useCallback, useRef, useMemo, MutableRefObject, useState } from 'react';
 import { Chart, Event } from '@antv/g2';
 
+export interface InterceptorOptions {
+  visible?: boolean;
+  offsetY?: number;
+  fixedOffsetY?: number;
+  more?: boolean;
+  offset?: number;
+  fixedOffset?: number;
+}
+
 const useInterceptors = () => {
   const triggerActionRef: MutableRefObject<string> = useRef('');
   const chartRef: MutableRefObject<Chart | null> = useRef(null);
@@ -24,16 +33,20 @@ const useInterceptors = () => {
       bindTooltip(r: any) {
         tooltipRef.current = r?.current;
       },
-      bindElementEvents(chart: Chart, options: { more?: boolean; offset?: number } = {}) {
+      bindElementEvents(chart: Chart, options: InterceptorOptions = {}) {
         chartRef.current = chart;
         chart.on('element:click', () => {
           /* istanbul ignore next */
           if (triggerActionRef.current !== 'click' && tooltipRef.current && options.more) {
-            const { top = '' } = tooltipRef?.current?.style || {};
-            const y = Number(top.replace('px', ''));
-            const offset = options.offset || 70;
-            if (y && y > offset) {
-              tooltipRef.current.style.top = `${y - offset}px`;
+            const tipStyles = window.getComputedStyle(tooltipRef?.current);
+            const top = parseInt(tipStyles.top);
+            const height = parseInt(tipStyles.height);
+
+            const { offset = 70, fixedOffset } = options;
+            if (fixedOffset) {
+              tooltipRef.current.style.top = `${top + height - fixedOffset}px`;
+            } else if (top && top > offset) {
+              tooltipRef.current.style.top = `${top - offset}px`;
             }
           }
           triggerActionRef.current = 'click';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import { LooseObject, ShapeAttrs } from '@antv/g-base';
 import { Chart, Element, Scale, View } from '@antv/g2';
 import { AdjustOption, AdjustType, ScaleOption } from '@antv/g2/lib/interface';
 import { PropsWithChildren } from 'react';
+import { Interceptor } from './hooks/useInterceptors';
 import { LegendObject } from './legends/useLegends';
 
 export interface Actions {
@@ -95,6 +96,7 @@ export interface ChartOptions extends LooseObject {
    * set default styles for line or interval
    */
   defaultStyles?: ShapeStyle;
+  interceptors?: Interceptor;
 }
 
 export interface BaseChartConfig extends LooseObject {

--- a/src/line/demos/Line.stories.tsx
+++ b/src/line/demos/Line.stories.tsx
@@ -235,7 +235,7 @@ const SplitLineConfig = {
 };
 
 const SplitLineConfigArgs = {
-  legends: ['步步盈增', '步步盈增（上个月）'],
+  legends: ['步步盈增', { name: '步步盈增（上个月）', color: '#ea0606' }],
   data: dataWithSplit,
   config: SplitLineConfig,
 };

--- a/src/line/framework.ts
+++ b/src/line/framework.ts
@@ -90,6 +90,9 @@ export class LineBase extends BaseChart {
       line.adjust.call(line, shapeConfig.adjust as AdjustOtptionType);
     }
     line.position(shapeConfig.position);
+    if (shapeConfig?.shape) {
+      line.shape('split-line');
+    }
     if (shapeConfig.color) {
       line.color(shapeConfig.color);
       line.style(shapeConfig.color, (label: string) => {
@@ -103,9 +106,6 @@ export class LineBase extends BaseChart {
         style.lineWidth = 2;
         return style;
       });
-    }
-    if (shapeConfig?.shape) {
-      line.shape('split-line');
     }
     return line;
   };
@@ -149,7 +149,7 @@ export class Line extends LineBase {
       this.lineShape(this.instance, options, lineConfig);
       this.instance.render();
       // Sometimes, chart will render wrong axis labels, render again will be fine.
-      this.instance.render(true);
+      // this.instance.render(true);
     } catch (err) {
       /* istanbul ignore next */
       console.log(err);

--- a/src/utils/tools/shapes/lineSplitLine.ts
+++ b/src/utils/tools/shapes/lineSplitLine.ts
@@ -42,7 +42,9 @@ registerShape('line', 'split-line', {
     group.addShape('path', {
       attrs: {
         path: path1,
-        stroke: cfg.color,
+        // cfg?.style?.stroke 为通过style()设定的stroke颜色
+        // cfg.color 为默认的颜色
+        stroke: cfg?.style?.stroke || cfg.color,
         lineWidth: 2,
       },
     });
@@ -58,7 +60,7 @@ registerShape('line', 'split-line', {
     group.addShape('path', {
       attrs: {
         path: path2,
-        stroke: cfg.color,
+        stroke: cfg?.style?.stroke || cfg.color,
         lineWidth: 2,
         lineDash: [5, 2],
         opacity: 0.7,


### PR DESCRIPTION
1. 在split-line中，保持颜色的统一
2. 支持cursor: pointer 样式
3. tooltip支持点击固定偏移
在`chart.tooltip`中，删除对`clickOffset`的支持，改为：
```
tooltip: {
  clickOptions: {
    visible: true,
    offsetY: 100,
    fixedOffsetY: 120, // 同时配置offsetY和fixedOffsetY，fixedOffsetY具有更高的优先级
  }
}
```

